### PR TITLE
wrong word replacement

### DIFF
--- a/03-viz.Rmd
+++ b/03-viz.Rmd
@@ -775,7 +775,7 @@ fruits_counted <- data_frame(
 )
 ```
 
-We see both the `fruits` and `fruits_counted` data frames represent the same collection of fruit: three apples and two bananas. However, whereas `fruits` just lists the fruit:
+We see both the `fruits` and `fruits_counted` data frames represent the same collection of fruit: three apples and two oranges. However, whereas `fruits` just lists the fruit:
 
 ```{r, echo=FALSE}
 kable(


### PR DESCRIPTION
In 778 line replaced "bananas" into "oranges".